### PR TITLE
Docker fix (still compiling hapcut2)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,10 @@ RUN tar -xvzf biobambam2-2.0.87-release-20180301132713-x86_64-etch-linux-gnu.tar
 RUN apt-get install -y libbz2-dev liblzma-dev libcurl4-gnutls-dev
 RUN wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2
 RUN tar jxvf htslib-1.10.2.tar.bz2 && cd htslib-1.10.2 && make && make install
+RUN ldconfig /usr/local/lib
 RUN cd HapCUT2 && make
+RUN cp /tools/HapCUT2/build/extractHAIRS /usr/local/bin
+RUN cp /tools/HapCUT2/build/HAPCUT2 /usr/local/bin
+RUN parallel --citation
 #run INSTALLATION.sh to install dependencies in Docker
 #RUN chmod +x /INSTALLATION.sh && /INSTALLATION.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN ldconfig /usr/local/lib
 RUN cd HapCUT2 && make
 RUN cp /tools/HapCUT2/build/extractHAIRS /usr/local/bin
 RUN cp /tools/HapCUT2/build/HAPCUT2 /usr/local/bin
-RUN parallel --citation
+RUN mkdir -p /root/.parallel
+RUN touch /root/.parallel/will-cite
 #run INSTALLATION.sh to install dependencies in Docker
 #RUN chmod +x /INSTALLATION.sh && /INSTALLATION.sh

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
-mkdir hi-c; cp tests/hic_* hi-c/
-mkdir pacbioccs; cp tests/hifi.fastq pacbioccs/
-python pipeline.py --hic-path hi-c --pb-path pacbioccs/ --sample test --prefix out 
+mkdir -p hi-c; cp tests/hic_* hi-c/
+mkdir -p pacbioccs; cp tests/hifi.fastq pacbioccs/
+python pipeline.py --hic-path hi-c --pb-path pacbioccs --sample test --prefix out


### PR DESCRIPTION
Your pipeline script requires "HiC_repair.py", which is apparently not installed by conda. I have modified the Dockerfile to make the hapcut2 step work. However, the pipeline stops at compare step. Not sure if that is the end.