### PR TITLE
relocatable working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,33 @@ See our preprint here: [https://doi.org/10.1101/810341](https://doi.org/10.1101/
 
 ## Installation
 ```
-mkdir -p /wd/dipasm/
-cd /wd/dipasm/
+mkdir -p $PWD/dipasm/
+pushd $PWD/dipasm/
 git clone https://github.com/shilpagarg/DipAsm.git
-# swith to a proper brach in nessary
-cd /wd/dipasm/DipAsm/docker
+ swith to a proper brach in nessary
+popd
+pushd $PWD/dipasm/DipAsm/docker
 docker build -t dipasm .
-cd /wd/dipasm/DipAsm
-docker run -it --rm -v  /wd/dipasm/DipAsm:/wd/dipasm/DipAsm/ -v /var/run/docker.sock:/var/run/docker.sock dipasm:latest /bin/bash
+popd
+pushd $PWD/dipasm/DipAsm
+docker run -it --rm -v  $PWD/dipasm/DipAsm:/wd/dipasm/DipAsm/ -e HOSTWD=$PWD/dipasm/DipAsm -v /var/run/docker.sock:/var/run/docker.sock dipasm:latest /bin/bash
 ```
 
+The `docker run -it` will start an interactive docker container session. You will be in
+the virtual container envrionment which have the preinstall DipAsm and testing data. 
+
+
 ## Test example with docker
+
+You can run the test for DipAsm within the docker container environment by:
+
 ```
 cd /wd/dipasm/DipAsm
 bash test.sh | bash
 ```
 ### Run
+
+Here is a brife description of the `pipeline.py` command:
 
 ```
 usage: pipeline.py [-h] --hic-path PATH --pb-path PATH --sample NAME [--female]

--- a/dv.sh
+++ b/dv.sh
@@ -1,5 +1,5 @@
-INPUT_DIR="$1"
-OUTPUT_DIR="$1/alignment/pacbioccs/vcf"
+INPUT_DIR="$HOSTWD/test_output/out/"
+OUTPUT_DIR="$HOSTWD/test_output/out/alignment/pacbioccs/vcf"
 BIN_VERSION="0.8.0"
 SCAFF=$2
 PAT=`echo $SCAFF | sed 's/\([^\\]\);/\1\\\\;/g' | sed 's/\([^\\]\)=/\1\\\\=/g'`
@@ -7,6 +7,8 @@ echo $PAT
 
 #short=`echo $SCAFF | cut -d';' -f1 | cut -d'.' -f2`
 #echo $short
+echo INPUT DIR: ${INPUT_DIR}
+echo OUTDIR DIR: ${OUTPUT_DIR}
 docker run \
   -v "${INPUT_DIR}":"/input" \
   -v "${OUTPUT_DIR}":"/output" \


### PR DESCRIPTION
Make the working directory in the current host directory ($PWD), so a user does not need root permission to create a work dir. Running Docker will still need the root to set it for a system. @lh3 or @shilpagarg, please validate. Thanks