### PR TITLE
wget was not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@ See our preprint here: [https://doi.org/10.1101/810341](https://doi.org/10.1101/
 
 ## Installation
 ```
-mkdir -p $PWD/dipasm/
-pushd $PWD/dipasm/
+mkdir -p dipasm
+cd dipasm
 git clone https://github.com/shilpagarg/DipAsm.git
-# switch to a proper branch if necessary
-popd
-pushd $PWD/dipasm/DipAsm/docker
+cd DipAsm/docker
 docker build -t dipasm .
-popd
-docker run -it --rm -v  $PWD/dipasm/DipAsm:/wd/dipasm/DipAsm/ -e HOSTWD=$PWD/dipasm/DipAsm -v /var/run/docker.sock:/var/run/docker.sock dipasm:latest /bin/bash
+cd ../../..
+docker run -it --rm -v $PWD/dipasm/DipAsm:/wd/dipasm/DipAsm/ -e HOSTWD=$PWD/dipasm/DipAsm -v /var/run/docker.sock:/var/run/docker.sock dipasm:latest /bin/bash
 ```
 
 The `docker run -it` will start an interactive docker container session. You will be in

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,9 @@ RUN bash /tools/install_whdenovo.sh
 
 RUN apt-get install -y vim tree 
 RUN apt-get install -y docker.io
-RUN wget https://github.com/broadinstitute/picard/releases/download/2.20.2/picard.jar
+RUN wget --no-check-certificate https://github.com/broadinstitute/picard/releases/download/2.20.2/picard.jar
 RUN git clone https://github.com/shilpagarg/HapCUT2.git
-RUN wget https://github.com/gt1/biobambam2/releases/download/2.0.87-release-20180301132713/biobambam2-2.0.87-release-20180301132713-x86_64-etch-linux-gnu.tar.gz
+RUN wget --no-check-certificate https://github.com/gt1/biobambam2/releases/download/2.0.87-release-20180301132713/biobambam2-2.0.87-release-20180301132713-x86_64-etch-linux-gnu.tar.gz
 RUN tar -xvzf biobambam2-2.0.87-release-20180301132713-x86_64-etch-linux-gnu.tar.gz
 RUN apt-get install -y libbz2-dev liblzma-dev libcurl4-gnutls-dev
 RUN mkdir -p /root/.parallel


### PR DESCRIPTION
This PR adds `--no-check-certificate` to wget. Some version of wget can't download picard.jar without this option. My docker build failed without it.